### PR TITLE
Fix failure from adding group that exists

### DIFF
--- a/fuzzvm/install.sh
+++ b/fuzzvm/install.sh
@@ -11,7 +11,7 @@ set -o nounset
 sudo apt-get update;
 sudo apt-get install docker.io -y;
 
-sudo groupadd docker
+sudo groupadd -f docker
 sudo gpasswd -a ${USER} docker
 sudo service docker restart
 


### PR DESCRIPTION
The docker package probably always creates the 'docker' group also, so
the whole line could be removed.